### PR TITLE
prevent LastSearches from adding empty queries

### DIFF
--- a/Classes/ResultsetModifier/LastSearches.php
+++ b/Classes/ResultsetModifier/LastSearches.php
@@ -46,6 +46,11 @@ class Tx_Solr_ResultsetModifier_LastSearches implements Tx_Solr_ResultSetModifie
 	public function modifyResultSet(Tx_Solr_PiResults_ResultsCommand $resultCommand, array $resultSet) {
 		$this->configuration = $resultCommand->getParentPlugin()->getConfiguration();
 		$keywords = $resultCommand->getParentPlugin()->getSearch()->getQuery()->getKeywordsCleaned();
+		
+		$keywords = trim($keywords);
+		if(empty($keywords)) {
+			return $resultSet;
+		}
 
 		switch ($this->configuration['search.']['lastSearches.']['mode']) {
 			case 'user':


### PR DESCRIPTION
prevent LastSearches facet from adding empty search queries to the history
