### PR TITLE
Content extractor HTML comment bugfix

### DIFF
--- a/Classes/Typo3PageContentExtractor.php
+++ b/Classes/Typo3PageContentExtractor.php
@@ -69,27 +69,11 @@ class Tx_Solr_Typo3PageContentExtractor extends Tx_Solr_HtmlContentExtractor {
 	 * @return	string	HTML markup found between TYPO3SEARCH markers
 	 */
 	protected function extractContentMarkedForIndexing($html) {
-		$explodedContent  = preg_split('/\<\!\-\-[\s]?TYPO3SEARCH_/', $html);
-		$indexableContent = '';
-
-		if(count($explodedContent) > 1) {
-
-			foreach($explodedContent as $explodedContentPart) {
-				$contentPart = explode('-->', $explodedContentPart, 2);
-
-				if (trim($contentPart[0]) == 'begin') {
-					$indexableContent .= $contentPart[1];
-					$previousExplodedContentPart = '';
-				} elseif (trim($contentPart[0]) == 'end') {
-					$indexableContent .= $previousExplodedContentPart;
-				} else {
-					$previousExplodedContentPart = $explodedContentPart;
-				}
-			}
-		} else {
-			if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['indexing.']['missingTypo3SearchMarkers']) {
-				t3lib_div::devLog('No TYPO3SEARCH markers found.', 'solr', 2);
-			}
+		preg_match_all('/\<\!\-\-[\s]?TYPO3SEARCH_begin[\s]?\-\-\>(.|\s)*?\<\!\-\-[\s]?TYPO3SEARCH_end[\s]?\-\-\>/mi', $html, $indexableContents);
+		$indexableContent = implode($indexableContents[0], '');
+		
+		if(empty($indexableContent) && $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_solr.']['logging.']['indexing.']['missingTypo3SearchMarkers']) {
+			t3lib_div::devLog('No TYPO3SEARCH markers found.', 'solr', 2);
 		}
 
 		return $indexableContent;


### PR DESCRIPTION
The extractor was not working correctly, if there were HTML comments in between the markers. This change should also make extraction proccess more performant.
