### PR TITLE
Cleanup page indexer request class

### DIFF
--- a/Classes/IndexQueue/PageIndexerRequest.php
+++ b/Classes/IndexQueue/PageIndexerRequest.php
@@ -141,7 +141,7 @@ class Tx_Solr_IndexQueue_PageIndexerRequest {
 			)
 		));
 
-		$rawResponse = file_get_contents($url, FALSE, $context);
+		$rawResponse = @file_get_contents($url, FALSE, $context);
 
 			// convert JSON response to response object properties
 		$decodedResponse = $response->getResultsFromJson($rawResponse);

--- a/Classes/IndexQueue/PageIndexerRequest.php
+++ b/Classes/IndexQueue/PageIndexerRequest.php
@@ -209,7 +209,6 @@ class Tx_Solr_IndexQueue_PageIndexerRequest {
 			'actions'   => implode(',', $this->actions),
 			'hash'      => md5(
 				$itemId . '|' .
-				$pageId . '|' .
 				$GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey']
 			)
 		);

--- a/Classes/IndexQueue/PageIndexerRequest.php
+++ b/Classes/IndexQueue/PageIndexerRequest.php
@@ -26,58 +26,58 @@
 /**
  * Index Queue Page Indexer request with details about which actions to perform.
  *
- * @author	Ingo Renner <ingo@typo3.org>
- * @package	TYPO3
- * @subpackage	solr
+ * @author Ingo Renner <ingo@typo3.org>
+ * @package TYPO3
+ * @subpackage solr
  */
 class Tx_Solr_IndexQueue_PageIndexerRequest {
 
 	/**
 	 * List of actions to perform during page rendering.
 	 *
-	 * @var	array
+	 * @var array
 	 */
 	protected $actions = array();
 
 	/**
 	 * Parameters as sent from the Index Queue page indexer.
 	 *
-	 * @var	array
+	 * @var array
 	 */
 	protected $parameters = array();
 
 	/**
 	 * Headers as sent from the Index Queue page indexer.
 	 *
-	 * @var	array
+	 * @var array
 	 */
 	protected $header = array();
 
 	/**
 	 * Unique request ID.
 	 *
-	 * @var	string
+	 * @var string
 	 */
 	protected $requestId;
 
 	/**
 	 * Username to use for basic auth protected URLs.
 	 *
-	 * @var	string
+	 * @var string
 	 */
 	protected $username = '';
 
 	/**
 	 * Password to use for basic auth protected URLs.
 	 *
-	 * @var	string
+	 * @var string
 	 */
 	protected $password = '';
 
 	/**
 	 * An Index Queue item related to this request.
 	 *
-	 * @var	Tx_Solr_IndexQueue_Item
+	 * @var Tx_Solr_IndexQueue_Item
 	 */
 	protected $indexQueueItem = NULL;
 
@@ -91,7 +91,7 @@ class Tx_Solr_IndexQueue_PageIndexerRequest {
 	/**
 	 * Constructor for Tx_Solr_IndexQueue_PageIndexerRequest
 	 *
-	 * @param	string	$header	JSON encoded Index Queue page indexer parameters
+	 * @param string $header JSON encoded Index Queue page indexer parameters
 	 */
 	public function __construct($header = NULL) {
 		$this->requestId = uniqid();
@@ -116,11 +116,11 @@ class Tx_Solr_IndexQueue_PageIndexerRequest {
 	/**
 	 * Executes the request.
 	 *
-	 * Uses headers to submit additonal data and avoiding to have these
+	 * Uses headers to submit additional data and avoiding to have these
 	 * arguments integrated into the URL when created by RealURL.
 	 *
-	 * @param	string	$url The URL to request.
-	 * @return	Tx_Solr_IndexQueue_PageIndexerResponse	Response
+	 * @param string $url The URL to request.
+	 * @return Tx_Solr_IndexQueue_PageIndexerResponse Response
 	 */
 	public function send($url) {
 		$headers  = $this->getHeaders();
@@ -196,7 +196,7 @@ class Tx_Solr_IndexQueue_PageIndexerRequest {
 	/**
 	 * Generates the headers to be send with the request.
 	 *
-	 * @return	array	Array of HTTP headers.
+	 * @return array Array of HTTP headers.
 	 */
 	public function getHeaders() {
 		$headers   = $this->header;
@@ -229,7 +229,7 @@ class Tx_Solr_IndexQueue_PageIndexerRequest {
 	 * Checks whether this is a legitimate request coming from the Index Queue
 	 * page indexer worker task.
 	 *
-	 * @return	boolean	TRUE if it's a legitimate request, FALSE otherwise.
+	 * @return boolean TRUE if it's a legitimate request, FALSE otherwise.
 	 */
 	public function isAuthenticated() {
 		$authenticated = FALSE;
@@ -252,7 +252,7 @@ class Tx_Solr_IndexQueue_PageIndexerRequest {
 	/**
 	 * Adds an action to perform during page rendering.
 	 *
-	 * @param	string	$action Action name.
+	 * @param string $action Action name.
 	 */
 	public function addAction($action) {
 		$this->actions[] = $action;
@@ -261,7 +261,7 @@ class Tx_Solr_IndexQueue_PageIndexerRequest {
 	/**
 	 * Gets the list of actions to perform during page rendering.
 	 *
-	 * @return	array	List of actions
+	 * @return array	List of actions
 	 */
 	public function getActions() {
 		return $this->actions;
@@ -270,7 +270,7 @@ class Tx_Solr_IndexQueue_PageIndexerRequest {
 	/**
 	 * Gets the request's parameters.
 	 *
-	 * @return	array	Request parameters.
+	 * @return array Request parameters.
 	 */
 	public function getParameters() {
 		return $this->parameters;
@@ -279,7 +279,7 @@ class Tx_Solr_IndexQueue_PageIndexerRequest {
 	/**
 	 * Gets the request's unique ID.
 	 *
-	 * @return	string	Unique request ID.
+	 * @return string Unique request ID.
 	 */
 	public function getRequestId() {
 		return $this->requestId;
@@ -288,8 +288,8 @@ class Tx_Solr_IndexQueue_PageIndexerRequest {
 	/**
 	 * Gets a specific parameter's value.
 	 *
-	 * @param	string	$parameterName The parameter to retrieve.
-	 * @return	mixed	NULL if a parameter was not set or it's value otherwise.
+	 * @param string $parameterName The parameter to retrieve.
+	 * @return mixed NULL if a parameter was not set or it's value otherwise.
 	 */
 	public function getParameter($parameterName) {
 		$value = NULL;
@@ -304,8 +304,9 @@ class Tx_Solr_IndexQueue_PageIndexerRequest {
 	/**
 	 * Sets a request's parameter and its value.
 	 *
-	 * @param	string	$parameter Parameter name
-	 * @param	mixed	$value Parameter value.
+	 * @param string $parameter Parameter name
+	 * @param mixed $value Parameter value.
+	 * @return void
 	 */
 	public function setParameter($parameter, $value) {
 		if (is_bool($value)) {
@@ -318,8 +319,9 @@ class Tx_Solr_IndexQueue_PageIndexerRequest {
 	/**
 	 * Sets username and password to be used for a basic auth request header.
 	 *
-	 * @param	string	$username username.
-	 * @param	string	$password password.
+	 * @param string $username username.
+	 * @param string $password password.
+	 * @return void
 	 */
 	public function setAuthorizationCredentials($username, $password) {
 		$this->username = $username;
@@ -330,6 +332,7 @@ class Tx_Solr_IndexQueue_PageIndexerRequest {
 	 * Sets the Index Queue item this request is related to.
 	 *
 	 * @param Tx_Solr_IndexQueue_Item $item Related Index Queue item.
+	 * @return void
 	 */
 	public function setIndexQueueItem(Tx_Solr_IndexQueue_Item $item) {
 		$this->indexQueueItem = $item;
@@ -354,7 +357,7 @@ class Tx_Solr_IndexQueue_PageIndexerRequest {
 	}
 }
 
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/solr/Classes/IndexQueue/PageIndexerRequest.php'])	{
+if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/solr/Classes/IndexQueue/PageIndexerRequest.php']) {
 	include_once($GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/solr/Classes/IndexQueue/PageIndexerRequest.php']);
 }
 


### PR DESCRIPTION
- adjusting some php docs
- remove an unused variable $pageId in the getHeader method. It was also duplicated because itemId will be equal to the pageId in the page indexer
- Prevent warnings while indexing pages. The pages will be logged with errors so why should i see the warning in the scheduler?
