### PR TITLE
[TASK] Improve language overlay handling for records

### DIFF
--- a/Classes/IndexQueue/Indexer.php
+++ b/Classes/IndexQueue/Indexer.php
@@ -184,10 +184,10 @@ class Tx_Solr_IndexQueue_Indexer extends Tx_Solr_IndexQueue_AbstractIndexer {
 		$rootPageUid = $item->getRootPageUid();
 		$overlayIdentifier = $rootPageUid . '|' . $language;
 		if (!isset(self::$sysLanguageOverlay[$overlayIdentifier])) {
-			Tx_Solr_Util::initializeTsfe($rootPageUid, $language);
 			self::$sysLanguageContent[$overlayIdentifier] = $GLOBALS['TSFE']->sys_language_content;
 			self::$sysLanguageOverlay[$overlayIdentifier] = $GLOBALS['TSFE']->sys_language_contentOL;
 		}
+		Tx_Solr_Util::initializeTsfe($rootPageUid, $language);
 
 		$itemRecord = $item->getRecord();
 


### PR DESCRIPTION
Solr record indexer does not handle language overlay efficiently and does not support content fallback.

Firsts, the cache for language information is not kept across instances of the indexer. Each new record
requires a new instance of the indexer but language information does not change between creation of
indexer instances. Language information is obtained by instantiating TSFE and parsing TS templates.
This can take 0.5-2 seconds depending on the amount of TypoScript. It makes sense to cache this
information statically. It helps to shorten indexing times dramatically.

Secondly, if there is content overlay, than records like news will be properly overlayed by the
corrsponding news plugin (i.e. you can see de_DE record instead of de_CH if de_CH does not exist) but
solr indexer will only give a record in the default language in such case, which is unexpected result
for the customer.

This commit fixes both issues. It is implemented as a single change because it is highly connected
code.
